### PR TITLE
Adds support for the pickup points deliveries

### DIFF
--- a/src/Adapters/ParcelAdapter.php
+++ b/src/Adapters/ParcelAdapter.php
@@ -212,6 +212,16 @@ final class ParcelAdapter extends BaseAdapter
                 'getter' => 'getAdditionalPrivacyText',
                 'xmlElement' => 'InfoPrivacy',
                 'maxLength' => 50
+            ],
+            [
+                'getter' => 'getPickUpDelivery',
+                'xmlElement' => 'FermoDeposito',
+                'maxLength' => 1
+            ],
+            [
+                'getter' => 'getPickUpPoint',
+                'xmlElement' => 'SiglaSedeFermoDeposito',
+                'maxLength' => 4
             ]
         ]
     ];

--- a/src/Models/Parcel.php
+++ b/src/Models/Parcel.php
@@ -394,6 +394,40 @@ final class Parcel extends BaseModel
     private $additionalPrivacyText = 'Per info sul trattamento dati personali www.gls-italy.com/privacydest';
 
     /**
+     * Enabling pickup point delivery provided by the GLS Italy DepotPickupService.
+     * Link: https://gls-group.com/IT/it/spedire-ricevere/servizio-per-te/servizi-accessori/depotpickup.
+     *
+     * s = enable pickup point delivery.
+     * Any other value or empty = option disabled.
+     *
+     * Max length is 1.
+     *
+     * From the GLS documentation:
+     *     Se “s” allora attiva il calcolo del “Fermo Deposito” usando l’indirizzo
+     *     specificato per identificare la sigla sede di Fermo Deposito
+     *
+     * @var string
+     */
+    private $pickUpDelivery;
+
+    /**
+     * The actual pickup point where recipient will get the parcel.
+     * For this to work the $pickUp needs to be set to 's' ( enabled ).
+     *
+     * To get the identifier of the pickup point, you should use CheckAddress GLS Italy Service.
+     * https://checkaddress.gls-italy.com/wscheckaddress.asmx
+     *
+     * Max length is 4.
+     *
+     * @var string
+     *
+     *  From the GLS documentation:
+     *     I valori ammessi sono le sigle sedi GLS che fanno fermo deposito
+     *    (verificare mediante metodo CheckDepotPickUp() )
+     */
+    private $pickUpPoint;
+
+    /**
      * Status setter
      * @param string $status
      */
@@ -494,9 +528,9 @@ final class Parcel extends BaseModel
 
     /**
      * Postcode getter
-     * @return string
+     * @return string|null
      */
-    public function getPostcode(): string
+    public function getPostcode(): ?string
     {
         return $this->postcode;
     }
@@ -584,9 +618,9 @@ final class Parcel extends BaseModel
 
     /**
      * Weight getter
-     * @return string
+     * @return string|null
      */
-    public function getWeight(): string
+    public function getWeight(): ?string
     {
         return $this->weight;
     }
@@ -949,5 +983,41 @@ final class Parcel extends BaseModel
     public function getAdditionalPrivacyText(): ?string
     {
         return $this->additionalPrivacyText;
+    }
+
+        /**
+     * PickUpDelivery setter
+     * @param string $value
+     */
+    public function setPickUpDelivery(string $value): void
+    {
+        $this->pickUpDelivery = $value;
+    }
+
+    /**
+     * PickUpDelivery getter.
+     * @return string|null
+     */
+    public function getPickUpDelivery(): ?string
+    {
+        return $this->pickUpDelivery;
+    }
+
+    /**
+     * PickUpPoint setter
+     * @param string $value
+     */
+    public function setPickUpPoint(string $value): void
+    {
+        $this->pickUpPoint = $value;
+    }
+
+    /**
+     * PickUpPoint setter
+     * @param string $value
+     */
+    public function getPickUpPoint(): ?string
+    {
+        return $this->pickUpPoint;
     }
 }

--- a/src/Responses/AddParcelResponse.php
+++ b/src/Responses/AddParcelResponse.php
@@ -21,7 +21,7 @@ final class AddParcelResponse extends BaseResponse
     private $parcelId, $pdfLabel, $zplLabel, $senderName, $volumeWeight, $shippingDate, $glsDestination, $csm, $areaCode;
     private $infoPrivacy, $receiverName, $address, $city, $province, $description1, $description2, $shippingWeight;
     private $shippingNotes, $transportType, $senderInitials, $progressiveParcel, $parcelType, $glsDestinationAbbr;
-    private $printer, $totalPackages, $error;
+    private $printer, $totalPackages, $pickUpDelivery, $pickUpPoint, $error;
 
     /**
      * Parcel id setter
@@ -471,6 +471,42 @@ final class AddParcelResponse extends BaseResponse
     public function getTotalPackages(): string
     {
         return $this->totalPackages;
+    }
+
+        /**
+     * pickUpDelivery setter.
+     * @param string $pickUpDelivery
+     */
+    public function setPickUpDelivery(string $pickUpDelivery): void
+    {
+        $this->pickUpDelivery = $pickUpDelivery;
+    }
+
+    /**
+     * pickUpDelivery getter.
+     * @return string
+     */
+    public function getPickUpDelivery(): string
+    {
+        return $this->pickUpDelivery;
+    }
+
+    /**
+     * pickUpPoint setter.
+     * @param string $pickUpPoint
+     */
+    public function setPickUpPoint(string $pickUpPoint): void
+    {
+        $this->pickUpPoint = $pickUpPoint;
+    }
+
+    /**
+     * pickUpPoint getter.
+     * @return string
+     */
+    public function getPickUpPoint(): string
+    {
+        return $this->pickUpPoint;
     }
 
     /**


### PR DESCRIPTION
This commit extends the package to support pickup point delivery provided by the GLS Italy DepotPickupService.
 
Pickup points can be found here: https://gls-group.com/IT/it/spedire-ricevere/servizio-per-te/servizi-accessori/depotpickup.

To fetch point identifier or any other info about a pickup point, use CheckAddress GLS Italy Service (https://checkaddress.gls-italy.com/wscheckaddress.asmx). 