### PR TITLE
Added progressiveId for multi-parcel shipments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,11 @@
     },
     "autoload-dev": {
         "psr-4": { "MarkoSirec\\Tests\\GlsItaly\\SDK\\": "tests/" }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/damianostevanato/gls-italy-sdk.git"
+        }
+    ]
 }

--- a/src/Adapters/ParcelAdapter.php
+++ b/src/Adapters/ParcelAdapter.php
@@ -238,6 +238,13 @@ final class ParcelAdapter extends BaseAdapter
                 'xmlElement' => 'TelefonoDestinatario',
                 'maxLength' => 16
             ],
+            [
+                'getter' => 'getProgressiveId',
+                'xmlElement' => 'ContatoreProgressivo',
+                'maxLength' => 9,
+                'errorMessage' => 'Missing parcel progressive id',
+                'required' => false,
+            ],
         ]
     ];
 

--- a/src/Adapters/ParcelAdapter.php
+++ b/src/Adapters/ParcelAdapter.php
@@ -350,6 +350,16 @@ final class ParcelAdapter extends BaseAdapter
 
         return $parcels;
     }
+    /**
+     * Parses the response when trying to get pdf label
+     * @param  string $result The raw xml response from Gls
+     * @return string          base64 pdf label
+     */
+    public static function parseGetPdfResponse(string $result): array
+    {
+        $result = new \SimpleXMLElement($result);
+        return $result->base64Binary;
+    }
 
     /**
      * Parses the individual parcel from Gls

--- a/src/Adapters/ParcelAdapter.php
+++ b/src/Adapters/ParcelAdapter.php
@@ -358,7 +358,7 @@ final class ParcelAdapter extends BaseAdapter
     public static function parseGetPdfResponse(string $result): string
     {
         $result = new \SimpleXMLElement($result);
-        return $result->xpath("base64Binary");
+        return $result->__toString();
     }
 
     /**

--- a/src/Adapters/ParcelAdapter.php
+++ b/src/Adapters/ParcelAdapter.php
@@ -355,10 +355,10 @@ final class ParcelAdapter extends BaseAdapter
      * @param  string $result The raw xml response from Gls
      * @return string          base64 pdf label
      */
-    public static function parseGetPdfResponse(string $result): array
+    public static function parseGetPdfResponse(string $result): string
     {
         $result = new \SimpleXMLElement($result);
-        return $result->base64Binary;
+        return $result->xpath("base64Binary");
     }
 
     /**

--- a/src/Models/Parcel.php
+++ b/src/Models/Parcel.php
@@ -427,6 +427,8 @@ final class Parcel extends BaseModel
      */
     private $pickUpPoint;
 
+    private $progressiveId;
+
     /*
      * Shipment type (used for international shipments)
      *  P = Parcel
@@ -1106,5 +1108,26 @@ final class Parcel extends BaseModel
     public function setReferencePersonPhoneNumber(?string $referencePersonPhoneNumber): void
     {
         $this->referencePersonPhoneNumber = $referencePersonPhoneNumber;
+    }
+
+
+    /**
+     * Auto increment parcel id setter
+     *
+     * @param ?string $progressiveId
+     */
+    public function setProgressiveId(?string $progressiveId): void
+    {
+        $this->progressiveId = $progressiveId;
+    }
+
+    /**
+     * Auto increment parcel id getter
+     *
+     * @return  ?string $progressiveId
+     */
+    public function getProgressiveId() :?string
+    {
+        return $this->progressiveId;
     }
 }

--- a/src/Services/ParcelService.php
+++ b/src/Services/ParcelService.php
@@ -73,11 +73,24 @@ final class ParcelService extends BaseService
         $result = static::get('ListSpedPeriod', $params);
         return ParcelAdapter::parseListResponse($result);
     }
-    public static function getPdf(Auth $auth, int $progressiveId){
-        $authAdapter = new AuthAdapter($auth);
-        $params = (array)$authAdapter->get();
-        $params['ContatoreProgressivo'] = $progressiveId;
-        return static::get('GetPdf',$params);
+
+    /**
+     * Get the label pdf as base64 for the specified parcel progressiveId
+     * @param Auth $auth
+     * @param int $progressiveId
+     * @return string
+     */
+    public static function getPdf(Auth $auth, int $progressiveId) : string
+    {
+        $params = [
+            'SedeGls' => $auth->getBranchId(),
+            'CodiceCliente' => $auth->getClientId(),
+            'Password' => $auth->getPassword(),
+            'CodiceContratto' => $auth->getContractId(),
+            'ContatoreProgressivo' => $progressiveId,
+        ];
+        $result = static::get('GetPdf',$params);
+        return ParcelAdapter::parseGetPdfResponse($result);
     }
     /**
      * Adds parcels

--- a/src/Services/ParcelService.php
+++ b/src/Services/ParcelService.php
@@ -73,7 +73,12 @@ final class ParcelService extends BaseService
         $result = static::get('ListSpedPeriod', $params);
         return ParcelAdapter::parseListResponse($result);
     }
-
+    public static function getPdf(Auth $auth, int $progressiveId){
+        $authAdapter = new AuthAdapter($auth);
+        $params = (array)$authAdapter->get();
+        $params['ContatoreProgressivo'] = $progressiveId;
+        return static::get('GetPdf',$params);
+    }
     /**
      * Adds parcels
      * @param Auth   $auth   Instance of the Auth object


### PR DESCRIPTION
From gls documentation , when creating a multi-parcel shipments its required to specify an auto-increment id, i've added a setter and getter method to add this property so i can use this package to create multi-parcel shipments
so now it can be setted like this 

$parcel->setProgressiveId(random_int(100000000,999999999));

and this should be set for every parcel created 
